### PR TITLE
Refactor: #17-match

### DIFF
--- a/src/main/java/com/example/moim/club/dto/ClubInput.java
+++ b/src/main/java/com/example/moim/club/dto/ClubInput.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
+@NoArgsConstructor
 public class ClubInput {
 
     @NotBlank(message = "모임 이름을 적어야합니다!")

--- a/src/main/java/com/example/moim/global/entity/AgeRange.java
+++ b/src/main/java/com/example/moim/global/entity/AgeRange.java
@@ -1,0 +1,26 @@
+package com.example.moim.global.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum AgeRange {
+    TWENTIES("20대"),
+    THIRTIES("30대"),
+    FORTIES("40대"),
+    FIFTIES_PLUS("50대 +");
+
+    private final String koreanName;
+
+    AgeRange(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public static AgeRange fromKoreanName(String koreanName) {
+        for (AgeRange area : AgeRange.values()) {
+            if (area.getKoreanName().equals(koreanName)) {
+                return area;
+            }
+        }
+        throw new IllegalArgumentException("해당 한글 이름에 대응하는 AgeRange가 없습니다: " + koreanName);
+    }
+}

--- a/src/main/java/com/example/moim/global/entity/EventType.java
+++ b/src/main/java/com/example/moim/global/entity/EventType.java
@@ -1,0 +1,25 @@
+package com.example.moim.global.entity;
+
+public enum EventType {
+    SOCCER("축구"), FUTSAL("풋살");
+
+    private final String koreanName;
+
+    EventType(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+
+    public static EventType fromKoreanName(String koreanName) {
+        for (EventType eventType : EventType.values()) {
+            if (eventType.getKoreanName().equals(koreanName)) {
+                return eventType;
+            }
+        }
+        throw new IllegalArgumentException("해당 한글 이름에 대응하는 EventType(이)가 없습니다: " + koreanName);
+    }
+}
+

--- a/src/main/java/com/example/moim/global/entity/Gender.java
+++ b/src/main/java/com/example/moim/global/entity/Gender.java
@@ -1,0 +1,24 @@
+package com.example.moim.global.entity;
+
+public enum Gender {
+    MAN("남성"), WOMAN("여성"), UNISEX("혼성");
+
+    private final String koreanName;
+
+    Gender(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+
+    public static Gender fromKoreanName(String koreanName) {
+        for (Gender gender : Gender.values()) {
+            if (gender.getKoreanName().equals(koreanName)) {
+                return gender;
+            }
+        }
+        throw new IllegalArgumentException("해당 한글 이름에 대응하는 Gender가 없습니다: " + koreanName);
+    }
+}

--- a/src/main/java/com/example/moim/global/exception/ResponseCode.java
+++ b/src/main/java/com/example/moim/global/exception/ResponseCode.java
@@ -34,12 +34,14 @@ public enum ResponseCode {
 
     // Match Error
     MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH4001", "매치를 찾을 수 없습니다."),
-    REQUIRE_FEE(HttpStatus.BAD_REQUEST, "MATCH4002", "대관비를 입력해주세요."),
-    REQUIRE_ACCOUNT(HttpStatus.BAD_REQUEST, "MATCH4003", "계좌번호를 입력해주세요."),
+    MATCH_REQUIRE_FEE(HttpStatus.BAD_REQUEST, "MATCH4002", "대관비를 입력해주세요."),
+    MATCH_REQUIRE_ACCOUNT(HttpStatus.BAD_REQUEST, "MATCH4003", "계좌번호를 입력해주세요."),
     MATCH_ALREADY_FOUND(HttpStatus.BAD_REQUEST, "MATCH4004", "이미 신청한 매치입니다."),
-    REGISTERED_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATCH4005", "가입된 동아리가 없습니다."),
-    APPLICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATCH4006", "올바른 매치가 아닙니다."),
-    TIME_OUT(HttpStatus.BAD_REQUEST, "MATCH4007", "매치가 종료된 후 48시간이 지났습니다."),
+    MATCH_APPLICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATCH4006", "올바른 매치가 아닙니다."),
+    MATCH_TIME_OUT(HttpStatus.BAD_REQUEST, "MATCH4007", "매치가 종료된 후 48시간이 지났습니다."),
+
+    // MatchUser Error
+    MATCH_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATCH4005", "가입된 모임이 없습니다."),
 
     // Token Error
     ACCESS_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "TOKEN4001", "헤더에 토큰 값이 없습니다"),

--- a/src/main/java/com/example/moim/global/exception/ResponseCode.java
+++ b/src/main/java/com/example/moim/global/exception/ResponseCode.java
@@ -29,6 +29,18 @@ public enum ResponseCode {
     // Review Error
     REVIEW_ALREADY_FOUND(HttpStatus.BAD_REQUEST, "REVIEW4001", "지정된 리뷰의 개수를 초과했습니다."),
 
+    // Club Error
+    CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB4001", "클럽을 찾을 수 없습니다."),
+
+    // Match Error
+    MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH4001", "매치를 찾을 수 없습니다."),
+    REQUIRE_FEE(HttpStatus.BAD_REQUEST, "MATCH4002", "대관비를 입력해주세요."),
+    REQUIRE_ACCOUNT(HttpStatus.BAD_REQUEST, "MATCH4003", "계좌번호를 입력해주세요."),
+    MATCH_ALREADY_FOUND(HttpStatus.BAD_REQUEST, "MATCH4004", "이미 신청한 매치입니다."),
+    REGISTERED_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATCH4005", "가입된 동아리가 없습니다."),
+    APPLICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATCH4006", "올바른 매치가 아닙니다."),
+    TIME_OUT(HttpStatus.BAD_REQUEST, "MATCH4007", "매치가 종료된 후 48시간이 지났습니다."),
+
     // Token Error
     ACCESS_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "TOKEN4001", "헤더에 토큰 값이 없습니다"),
     TOKEN_EXPIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "TOKEN4002", "토큰의 유효 기간이 만료되었습니다"),

--- a/src/main/java/com/example/moim/match/controller/MatchController.java
+++ b/src/main/java/com/example/moim/match/controller/MatchController.java
@@ -1,6 +1,7 @@
 package com.example.moim.match.controller;
 
 import com.example.moim.club.repository.ClubRepository;
+import com.example.moim.global.exception.BaseResponse;
 import com.example.moim.global.exception.ResponseCode;
 import com.example.moim.match.dto.*;
 import com.example.moim.match.exception.advice.MatchControllerAdvice;
@@ -25,93 +26,99 @@ public class MatchController {
     //매치 등록(생성) 신청(참가)
     //매치 생성
     @PostMapping("/match")
-    public MatchOutput matchSave(@RequestBody @Valid MatchInput matchInput, @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.saveMatch(userDetailsImpl.getUser(), matchInput);
+    public BaseResponse<MatchOutput> matchSave(@RequestBody @Valid MatchInput matchInput, @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
+        return BaseResponse.onSuccess(matchService.saveMatch(userDetailsImpl.getUser(), matchInput), ResponseCode.OK);
     }
 
     //매치 등록
     @PatchMapping(value = "/match", produces = MediaType.APPLICATION_JSON_VALUE)
-    public MatchRegOutput matchRegister(@RequestBody @Valid MatchRegInput matchRegInput,
+    public BaseResponse<MatchRegOutput> matchRegister(@RequestBody @Valid MatchRegInput matchRegInput,
                                         @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.registerMatch(userDetailsImpl.getUser(), matchRegInput);
+        return BaseResponse.onSuccess(matchService.registerMatch(userDetailsImpl.getUser(), matchRegInput), ResponseCode.OK);
     }
 
     //매치 신청 생성
     @PostMapping("/match-apply")
-    public MatchApplyOutput matchApplySave(@RequestParam Long matchId,
+    public BaseResponse<MatchApplyOutput> matchApplySave(@RequestParam Long matchId,
                                            @RequestParam Long clubId,
                                            @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.saveMatchApp(userDetailsImpl.getUser(), matchId, clubId);
+        return BaseResponse.onSuccess(matchService.saveMatchApp(userDetailsImpl.getUser(), matchId, clubId), ResponseCode.OK);
     }
 
     //매치 신청 완료
     @PatchMapping("/match-apply")
-    public MatchApplyOutput matchApply(@RequestBody @Valid MatchApplyInput matchApplyInput,
+    public BaseResponse<MatchApplyOutput> matchApply(@RequestBody @Valid MatchApplyInput matchApplyInput,
                                        @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.applyMatch(userDetailsImpl.getUser(), matchApplyInput);
+        return BaseResponse.onSuccess(matchService.applyMatch(userDetailsImpl.getUser(), matchApplyInput), ResponseCode.OK);
     }
 
     //매치 초청
     @PostMapping("/match-invite")
-    public ResponseEntity<String> matchInvite(@RequestParam Long matchId,
+    public BaseResponse<String> matchInvite(@RequestParam Long matchId,
                                               @RequestParam Long clubId,
                                               @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
         matchService.inviteMatch(userDetailsImpl.getUser(), matchId, clubId);
-        return ResponseEntity.ok("매치 초청 알림이 전송되었습니다.");
+        return BaseResponse.onSuccess("매치 초청 알림이 전송되었습니다.", ResponseCode.OK);
     }
 
     //매치 확정
     @PostMapping("/match-confirm")
-    public MatchConfirmOutput matchConfirm(@RequestParam Long matchId,
+    public BaseResponse<MatchConfirmOutput> matchConfirm(@RequestParam Long matchId,
                                            @RequestParam Long clubId,
                                            @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.confirmMatch(matchId, clubId, userDetailsImpl.getUser());
+        return BaseResponse.onSuccess(matchService.confirmMatch(matchId, clubId, userDetailsImpl.getUser()), ResponseCode.OK);
     }
 
     //등록된 매치 검색
     @GetMapping("/matches")
-    public List<MatchSearchOutput> findMatches(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
+    public BaseResponse<List<MatchSearchOutput>> findMatches(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
                                                @ModelAttribute MatchSearchCond matchSearchCond) {
-        return matchService.searchMatch(matchSearchCond);
+        return BaseResponse.onSuccess(matchService.searchMatch(matchSearchCond), ResponseCode.OK);
     }
 
     //확정된 매치리스트
     @GetMapping("/{clubId}/matches")
-    public List<ConfirmedMatchOutput> findConfirmedMatches(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
+    public BaseResponse<List<ConfirmedMatchOutput>> findConfirmedMatches(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
                                                            @PathVariable Long clubId) {
-        return matchService.findConfirmedMatch(clubRepository.findById(clubId).orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND)));
+        return BaseResponse.onSuccess(matchService.findConfirmedMatch(clubRepository.findById(clubId)
+                .orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND))),
+                ResponseCode.OK);
     }
 
     //활동 지역 소재 모임 리스트
     @GetMapping("/{clubId}/match-clubs")
-    public List<MatchClubOutput> findMatchClubs(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
+    public BaseResponse<List<MatchClubOutput>> findMatchClubs(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
                                                 @ModelAttribute MatchClubSearchCond matchClubSearchCond,
                                                 @PathVariable Long clubId) {
-        return matchService.searchMatchClubs(matchClubSearchCond, clubRepository.findById(clubId).orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND)));
+        return BaseResponse.onSuccess(matchService.searchMatchClubs(matchClubSearchCond, clubRepository.findById(clubId)
+                .orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND))),
+                ResponseCode.OK);
     }
 
     //매치 등록/신청 현황
     @GetMapping("/{clubId}/match-status")
-    public List<MatchStatusOutput> getMatchStatus(@PathVariable Long clubId) {
-        return matchService.findMatchStatus(clubRepository.findById(clubId)
-                .orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND)));
+    public BaseResponse<List<MatchStatusOutput>> getMatchStatus(@PathVariable Long clubId) {
+        return BaseResponse.onSuccess(matchService.findMatchStatus(clubRepository.findById(clubId)
+                .orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND))),
+                ResponseCode.OK);
     }
 
     //매치 결과 기록
     @PatchMapping(value = "/match/{matchId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public MatchRecordOutput matchRecordSave(@PathVariable Long matchId,
+    public BaseResponse<MatchRecordOutput> matchRecordSave(@PathVariable Long matchId,
                                              @RequestBody @Valid MatchRecordInput matchRecordInput,
                                              @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.saveMatchRecord(matchRepository.findById(matchId)
+        return BaseResponse.onSuccess(matchService.saveMatchRecord(matchRepository.findById(matchId)
                         .orElseThrow(() -> new MatchControllerAdvice(ResponseCode.MATCH_NOT_FOUND)),
                 userDetailsImpl.getUser(),
-                matchRecordInput);
+                matchRecordInput),
+                ResponseCode.OK);
     }
 
     //매치 메인 페이지(대시보드)
     @GetMapping("match/main/{clubId}")
-    public MatchMainOutput findMatchMain(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.matchMainFind(clubId, userDetailsImpl.getUser());
+    public BaseResponse<MatchMainOutput> findMatchMain(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
+        return BaseResponse.onSuccess(matchService.matchMainFind(clubId, userDetailsImpl.getUser()), ResponseCode.OK);
     }
 
 }

--- a/src/main/java/com/example/moim/match/controller/MatchController.java
+++ b/src/main/java/com/example/moim/match/controller/MatchController.java
@@ -1,7 +1,9 @@
 package com.example.moim.match.controller;
 
 import com.example.moim.club.repository.ClubRepository;
+import com.example.moim.global.exception.ResponseCode;
 import com.example.moim.match.dto.*;
+import com.example.moim.match.exception.advice.MatchControllerAdvice;
 import com.example.moim.match.repository.MatchRepository;
 import com.example.moim.match.service.MatchService;
 import com.example.moim.user.dto.UserDetailsImpl;
@@ -77,7 +79,7 @@ public class MatchController {
     @GetMapping("/{clubId}/matches")
     public List<ConfirmedMatchOutput> findConfirmedMatches(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
                                                            @PathVariable Long clubId) {
-        return matchService.findConfirmedMatch(clubRepository.findById(clubId).get());
+        return matchService.findConfirmedMatch(clubRepository.findById(clubId).orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND)));
     }
 
     //활동 지역 소재 모임 리스트
@@ -85,13 +87,14 @@ public class MatchController {
     public List<MatchClubOutput> findMatchClubs(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl,
                                                 @ModelAttribute MatchClubSearchCond matchClubSearchCond,
                                                 @PathVariable Long clubId) {
-        return matchService.searchMatchClubs(matchClubSearchCond, clubRepository.findById(clubId).get());
+        return matchService.searchMatchClubs(matchClubSearchCond, clubRepository.findById(clubId).orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND)));
     }
 
     //매치 등록/신청 현황
     @GetMapping("/{clubId}/match-status")
     public List<MatchStatusOutput> getMatchStatus(@PathVariable Long clubId) {
-        return matchService.findMatchStatus(clubRepository.findById(clubId).get());
+        return matchService.findMatchStatus(clubRepository.findById(clubId)
+                .orElseThrow(() -> new MatchControllerAdvice(ResponseCode.CLUB_NOT_FOUND)));
     }
 
     //매치 결과 기록
@@ -99,14 +102,16 @@ public class MatchController {
     public MatchRecordOutput matchRecordSave(@PathVariable Long matchId,
                                              @RequestBody @Valid MatchRecordInput matchRecordInput,
                                              @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return matchService.saveMatchRecord(matchRepository.findById(matchId).get(), userDetailsImpl.getUser(), matchRecordInput);
+        return matchService.saveMatchRecord(matchRepository.findById(matchId)
+                        .orElseThrow(() -> new MatchControllerAdvice(ResponseCode.MATCH_NOT_FOUND)),
+                userDetailsImpl.getUser(),
+                matchRecordInput);
     }
 
     //매치 메인 페이지(대시보드)
     @GetMapping("match/main/{clubId}")
     public MatchMainOutput findMatchMain(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
         return matchService.matchMainFind(clubId, userDetailsImpl.getUser());
-
     }
 
 }

--- a/src/main/java/com/example/moim/match/controller/MatchController.java
+++ b/src/main/java/com/example/moim/match/controller/MatchController.java
@@ -118,7 +118,7 @@ public class MatchController {
     //매치 메인 페이지(대시보드)
     @GetMapping("match/main/{clubId}")
     public BaseResponse<MatchMainOutput> findMatchMain(@PathVariable Long clubId, @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return BaseResponse.onSuccess(matchService.matchMainFind(clubId, userDetailsImpl.getUser()), ResponseCode.OK);
+        return BaseResponse.onSuccess(matchService.matchMainFind(clubId), ResponseCode.OK);
     }
 
 }

--- a/src/main/java/com/example/moim/match/dto/ConfirmedMatchOutput.java
+++ b/src/main/java/com/example/moim/match/dto/ConfirmedMatchOutput.java
@@ -1,6 +1,7 @@
 package com.example.moim.match.dto;
 
 import com.example.moim.club.entity.Club;
+import com.example.moim.global.entity.EventType;
 import com.example.moim.match.entity.Match;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
@@ -10,7 +11,7 @@ import java.time.LocalDate;
 @Data
 public class ConfirmedMatchOutput {
     private String OpponentClubName;
-    private String event;
+    private EventType event;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
     private LocalDate matchDate;
     private String location;

--- a/src/main/java/com/example/moim/match/dto/MatchClubSearchCond.java
+++ b/src/main/java/com/example/moim/match/dto/MatchClubSearchCond.java
@@ -1,5 +1,6 @@
 package com.example.moim.match.dto;
 
+import com.example.moim.global.entity.EventType;
 import lombok.Data;
 
 @Data

--- a/src/main/java/com/example/moim/match/dto/MatchInput.java
+++ b/src/main/java/com/example/moim/match/dto/MatchInput.java
@@ -1,12 +1,9 @@
 package com.example.moim.match.dto;
 
-import com.example.moim.match.entity.Gender;
-import com.example.moim.match.entity.Match;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Null;
 import lombok.Data;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/example/moim/match/dto/MatchSearchCond.java
+++ b/src/main/java/com/example/moim/match/dto/MatchSearchCond.java
@@ -1,5 +1,6 @@
 package com.example.moim.match.dto;
 
+import com.example.moim.global.entity.EventType;
 import lombok.Data;
 
 import java.time.LocalDate;

--- a/src/main/java/com/example/moim/match/dto/MatchSearchOutput.java
+++ b/src/main/java/com/example/moim/match/dto/MatchSearchOutput.java
@@ -1,5 +1,6 @@
 package com.example.moim.match.dto;
 
+import com.example.moim.global.entity.EventType;
 import com.example.moim.match.entity.Match;
 import lombok.Data;
 
@@ -11,7 +12,7 @@ public class MatchSearchOutput {
     private LocalDate matchDate;
     private String period;
     private String name;
-    private String event;
+    private EventType event;
     private String location;
 
     public MatchSearchOutput(Match match) {

--- a/src/main/java/com/example/moim/match/dto/RegisteredMatchDto.java
+++ b/src/main/java/com/example/moim/match/dto/RegisteredMatchDto.java
@@ -1,5 +1,6 @@
 package com.example.moim.match.dto;
 
+import com.example.moim.global.entity.EventType;
 import com.example.moim.match.entity.Match;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
@@ -9,7 +10,7 @@ import java.time.LocalDate;
 @Data
 public class RegisteredMatchDto implements Comparable<RegisteredMatchDto> {
     private String opponentClubName;
-    private String event;
+    private EventType event;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
     private LocalDate matchDate;
     private String location;

--- a/src/main/java/com/example/moim/match/entity/Gender.java
+++ b/src/main/java/com/example/moim/match/entity/Gender.java
@@ -1,5 +1,0 @@
-package com.example.moim.match.entity;
-
-public enum Gender {
-    MAN, WOMAN, UNISEX
-}

--- a/src/main/java/com/example/moim/match/entity/Match.java
+++ b/src/main/java/com/example/moim/match/entity/Match.java
@@ -1,5 +1,8 @@
 package com.example.moim.match.entity;
 
+import com.example.moim.global.entity.AgeRange;
+import com.example.moim.global.entity.EventType;
+import com.example.moim.global.entity.Gender;
 import com.example.moim.schedule.dto.ScheduleInput;
 import com.example.moim.club.entity.Club;
 import com.example.moim.schedule.entity.Schedule;
@@ -11,6 +14,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
+
 import static com.example.moim.match.entity.MatchHalf.*;
 import static com.example.moim.match.entity.MatchStatus.*;
 
@@ -31,30 +36,35 @@ public class Match extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "away_club_id")
     private Club awayClub;
-    private Integer homeScore;
-    private Integer awayScore;
+    private int homeScore;
+    private int awayScore;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
-
     private String name;
-    private String event;
-    private String matchSize; //종목 인원수
+
+    @Enumerated(EnumType.STRING)
+    private EventType event;
+    @Enumerated(EnumType.STRING)
+    private MatchSize matchSize;
+
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private String location;
+
     private int fee;
     private String bank;
     private String account;
-    private int minParticipants; //최소 참가자 수
+    private int minParticipants; //최소 참가자 수 (필요한가?)
 
     // 자동 등록
     @Enumerated(EnumType.STRING)
     private MatchStatus matchStatus;
     @Enumerated(EnumType.STRING)
     private Gender gender;
-    private String ageRange;
+    @Enumerated(EnumType.STRING)
+    private AgeRange ageRange;    // Enum 으로 변경
 
     private boolean isBall;
     private String note;
@@ -68,8 +78,8 @@ public class Match extends BaseEntity {
 
         match.homeClub = club;
         match.name = createMatchName(club, matchInput);
-        match.event = matchInput.getEvent();
-        match.matchSize = matchInput.getMatchSize();
+        match.event = EventType.fromKoreanName(matchInput.getEvent());
+        match.matchSize = MatchSize.fromKoreanName(matchInput.getMatchSize());
         match.startTime = matchInput.getStartTime();
         match.endTime = matchInput.getEndTime();
         match.location = matchInput.getLocation();
@@ -78,9 +88,9 @@ public class Match extends BaseEntity {
         match.account = matchInput.getAccount();
         match.minParticipants = matchInput.getMinParticipants();
 
-        match.gender = Gender.valueOf(club.getGender());
-        match.ageRange = club.getAgeRange();
-        match.matchStatus = PENDING;// 초기 상태는 매치 대기
+        match.gender = Gender.fromKoreanName(club.getGender());
+        match.ageRange = AgeRange.fromKoreanName(club.getAgeRange());
+        match.matchStatus = PENDING;    // 초기 상태는 매치 대기
         match.matchHalf = (matchInput.getStartTime().getMonth().getValue() <= 6) ? FIRST_HALF : SECOND_HALF;
         match.homeScore = 0;
         match.awayScore = 0;
@@ -113,6 +123,7 @@ public class Match extends BaseEntity {
         String clubName = club.getTitle();
         String matchType = matchInput.getEvent(); // 종목 (축구, 풋살 등)
         String participants = matchInput.getMatchSize(); // 인원수
+
         return String.format("%s팀의 %s %s 매치", clubName, participants, matchType);
     }
 
@@ -130,7 +141,7 @@ public class Match extends BaseEntity {
 
 
     public Club findOpponentClub(Club club) {
-        if (club.getId() == this.getAwayClub().getId()) {
+        if (Objects.equals(club.getId(), this.getAwayClub().getId())) {
             return this.getHomeClub();
         }
 

--- a/src/main/java/com/example/moim/match/entity/MatchSize.java
+++ b/src/main/java/com/example/moim/match/entity/MatchSize.java
@@ -1,0 +1,24 @@
+package com.example.moim.match.entity;
+
+public enum MatchSize {
+    SEVEN("7명"), ELEVEN("11명");
+
+    private final String koreanName;
+
+    MatchSize(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+
+    public static MatchSize fromKoreanName(String koreanName) {
+        for (MatchSize size : MatchSize.values()) {
+            if (size.getKoreanName().equals(koreanName)) {
+                return size;
+            }
+        }
+        throw new IllegalArgumentException("해당 한글 이름에 대응하는 MatchSize가 없습니다" + koreanName);
+    }
+}

--- a/src/main/java/com/example/moim/match/entity/MatchUser.java
+++ b/src/main/java/com/example/moim/match/entity/MatchUser.java
@@ -24,13 +24,14 @@ public class MatchUser {
     @ManyToOne(fetch = FetchType.LAZY)
     private Club club;
 
-    private Integer score;
+    private int score;
 
     public static MatchUser createMatchUser(Match match, ScheduleVote scheduleVote) {
         MatchUser matchUser = new MatchUser();
         matchUser.match = match;
         matchUser.user = scheduleVote.getUser();
         matchUser.club = findUserClubInMatch(match, scheduleVote.getUser());
+        matchUser.score = 0;
 
         return matchUser;
     }

--- a/src/main/java/com/example/moim/match/repository/MatchRepositoryImpl.java
+++ b/src/main/java/com/example/moim/match/repository/MatchRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.example.moim.match.repository;
 import com.example.moim.club.entity.Club;
 import com.example.moim.match.dto.MatchClubSearchCond;
 import com.example.moim.match.dto.MatchSearchCond;
-import com.example.moim.match.entity.Gender;
+import com.example.moim.global.entity.Gender;
 import com.example.moim.match.entity.Match;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -60,7 +60,7 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
 
     private BooleanExpression searchContains(String search) {
         if (hasText(search)) {
-            return match.event.contains(search)
+            return match.event.stringValue().contains(search)
                     .or(match.name.contains(search))
                     .or(match.location.contains(search))
                     .or(match.fee.stringValue().contains(search))
@@ -75,7 +75,7 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom {
     }
 
     private BooleanExpression matchTypeEq(String matchType) {
-        return matchType != null ? match.event.eq(matchType) : null;
+        return matchType != null ? match.event.stringValue().eq(matchType) : null;
     }
 
     private BooleanExpression genderEq(String gender) {

--- a/src/main/java/com/example/moim/match/service/MatchAggregateService.java
+++ b/src/main/java/com/example/moim/match/service/MatchAggregateService.java
@@ -31,7 +31,7 @@ public class MatchAggregateService {
             int homeScore = 0;
             int awayScore = 0;
             for (MatchUser matchUser : matchUserRepository.findByMatch(match)) {
-                if (matchUser.getScore() == null) {
+                if (matchUser.getScore() == 0) {
                     continue;
                 }
 

--- a/src/main/java/com/example/moim/match/service/MatchService.java
+++ b/src/main/java/com/example/moim/match/service/MatchService.java
@@ -243,6 +243,7 @@ public class MatchService {
         List<Match> matches = matchRepository.findRegisteredMatch(myClub);
         String[] myClubCoordinate = myClub.getUniversity().replace("@", ",").split(",");
         List<RegisteredMatchDto> registeredMatchDtos = new ArrayList<>(matches.size());
+
         for (Match match : matches) {
             String[] matchCoordinate = match.getLocation().replace("@", ",").split(",");
             registeredMatchDtos.add(new RegisteredMatchDto(match, distance(Double.parseDouble(myClubCoordinate[2]), Double.parseDouble(myClubCoordinate[1]),

--- a/src/test/java/com/example/moim/match/MatchAggregateServiceTest.java
+++ b/src/test/java/com/example/moim/match/MatchAggregateServiceTest.java
@@ -56,9 +56,6 @@ class MatchAggregateServiceTest {
         ReflectionTestUtils.setField(match, "awayScore", 0);
         // endTime는 현재시각에서 24시간 이전
         ReflectionTestUtils.setField(match, "endTime", LocalDateTime.now().minusHours(24));
-
-        when(homeClub.getId()).thenReturn(1L);
-        when(awayClub.getId()).thenReturn(2L);
     }
 
     @Test
@@ -74,7 +71,7 @@ class MatchAggregateServiceTest {
         ReflectionTestUtils.setField(matchUserAway, "user", new com.example.moim.user.entity.User());
 
         MatchUser matchUserNull = new MatchUser();
-        ReflectionTestUtils.setField(matchUserNull, "score", null);
+        ReflectionTestUtils.setField(matchUserNull, "score", 0);
         ReflectionTestUtils.setField(matchUserNull, "club", homeClub);
         ReflectionTestUtils.setField(matchUserNull, "user", new com.example.moim.user.entity.User());
 
@@ -125,7 +122,7 @@ class MatchAggregateServiceTest {
         when(matchUser2.getClub()).thenReturn(awayClub);
 
         MatchUser matchUser3 = Mockito.mock(MatchUser.class);
-        when(matchUser3.getScore()).thenReturn(null);
+        when(matchUser3.getScore()).thenReturn(0);
         when(matchUser3.getClub()).thenReturn(homeClub);
 
         List<MatchUser> matchUsers = Arrays.asList(matchUser1, matchUser2, matchUser3);
@@ -165,7 +162,7 @@ class MatchAggregateServiceTest {
 
         // match2: 홈 0, 원정 3 (하나는 null 점수)
         MatchUser m2User1 = Mockito.mock(MatchUser.class);
-        when(m2User1.getScore()).thenReturn(null);
+        when(m2User1.getScore()).thenReturn(0);
         when(m2User1.getClub()).thenReturn(homeClub);
 
         MatchUser m2User2 = Mockito.mock(MatchUser.class);

--- a/src/test/java/com/example/moim/match/MatchServiceTest.java
+++ b/src/test/java/com/example/moim/match/MatchServiceTest.java
@@ -545,7 +545,7 @@ class MatchServiceTest {
         when(matchRepository.findRegisteredMatch(club)).thenReturn(Arrays.asList(match));
         when(clubRepository.findByActivityArea(club.getActivityArea())).thenReturn(Arrays.asList(club));
 
-        MatchMainOutput output = matchService.matchMainFind(1L, user);
+        MatchMainOutput output = matchService.matchMainFind(1L);
         assertNotNull(output);
         assertEquals("Test Club", output.getClubTitle());
     }

--- a/src/test/java/com/example/moim/match/MatchServiceTest.java
+++ b/src/test/java/com/example/moim/match/MatchServiceTest.java
@@ -5,6 +5,7 @@ import com.example.moim.club.entity.Club;
 import com.example.moim.club.entity.UserClub;
 import com.example.moim.club.repository.ClubRepository;
 import com.example.moim.club.repository.UserClubRepository;
+import com.example.moim.global.entity.EventType;
 import com.example.moim.match.dto.*;
 import com.example.moim.match.entity.Match;
 import com.example.moim.match.entity.MatchApplication;
@@ -78,9 +79,9 @@ class MatchServiceTest {
         clubInput.setIntroduction("introduction");
         clubInput.setCategory("동아리");
         clubInput.setUniversity("TestUniv@37.5665@126.9780");
-        clubInput.setGender("MAN");
+        clubInput.setGender("남성");
         clubInput.setActivityArea("서울");
-        clubInput.setAgeRange("20-30");
+        clubInput.setAgeRange("20대");
         clubInput.setMainEvent("축구");
         clubInput.setClubPassword("password");
         clubInput.setMainUniformColor("흰색");
@@ -108,7 +109,7 @@ class MatchServiceTest {
         input.setLocation("test");
         input.setAccount("");
         input.setEvent("축구");
-        input.setMatchSize("11");
+        input.setMatchSize("11명");
         input.setMinParticipants(10);
         input.setBank("신한");
 
@@ -415,7 +416,7 @@ class MatchServiceTest {
         ReflectionTestUtils.setField(match, "endTime", LocalDateTime.now().minusHours(24)); // 48시간 이내
         MatchUser matchUser = new MatchUser();
         ReflectionTestUtils.setField(matchUser, "id", 950L);
-        ReflectionTestUtils.setField(matchUser, "score", null);
+        ReflectionTestUtils.setField(matchUser, "score", 0);
         ReflectionTestUtils.setField(matchUser, "user", user);
 
         when(matchUserRepository.findByMatchAndUser(match, user)).thenReturn(matchUser);
@@ -469,7 +470,7 @@ class MatchServiceTest {
         ReflectionTestUtils.setField(opponentClub, "title", "Opponent Club");
 
         ReflectionTestUtils.setField(match, "awayClub", opponentClub);
-        ReflectionTestUtils.setField(match, "event", "축구");
+        ReflectionTestUtils.setField(match, "event", EventType.SOCCER);
         LocalDateTime startTime = LocalDateTime.of(2025, 5, 10, 15, 0);
         LocalDateTime endTime = LocalDateTime.of(2025, 5, 10, 17, 0);
         ReflectionTestUtils.setField(match, "startTime", startTime);
@@ -488,7 +489,7 @@ class MatchServiceTest {
         // OpponentClubName은 match.findOpponentClub(club).getTitle()로 결정됨.
         // homeClub은 club, awayClub은 opponentClub이므로, opponentClub의 title이 반환되어야 함.
         assertEquals("Opponent Club", output.getOpponentClubName());
-        assertEquals("축구", output.getEvent());
+        assertEquals(EventType.SOCCER, output.getEvent());
         assertEquals(LocalDate.of(2025, 5, 10), output.getMatchDate());
         assertEquals("test location", output.getLocation());
 


### PR DESCRIPTION
## ✨ match 도메인 리팩터링

## 📌 변경 사항 (What’s changed?)
- match 엔티티의 필드 enum 변경
- optional - orElseThrow 변경
- 응답을 BaseResponse로 변경
- 필요없는 매개변수 제거

## ⚙️ 변경 이유 (Why?)
- 유지보수의 용이성과 null 안정성을 위한 리팩터링

## 💬리뷰 요구사항(선택)
BaseResponse 이렇게 사용하는것이 맞나요..? 확인해주시면 감사하겠습니다! 그리고 몇 개의 enum을 global에 추가했는데, 수정해야할 것이 있다면 말씀해주세요!
