### PR TITLE
✨ feat: 유저 내보내기 기능 구현

### DIFF
--- a/src/main/java/com/example/moim/club/controller/ClubController.java
+++ b/src/main/java/com/example/moim/club/controller/ClubController.java
@@ -80,11 +80,10 @@ public class ClubController implements ClubControllerDocs{
     }
 
     @PatchMapping(value = "/clubs/{id}/password", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public BaseResponse clubPasswordUpdate(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody @Valid ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable("id") Long clubId) {
+    public BaseResponse<String> clubPasswordUpdate(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody @Valid ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable("id") Long clubId) {
 //    public BaseResponse clubPasswordUpdate(@RequestBody @Valid ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable("id") Long clubId) {
 //        User user = userRepository.findById(1L).get();
-        clubCommandService.clubPasswordUpdate(userDetailsImpl.getUser(), clubPswdUpdateInput, clubId);
-        return BaseResponse.onSuccess(null, ResponseCode.OK);
+        return BaseResponse.onSuccess(clubCommandService.clubPasswordUpdate(userDetailsImpl.getUser(), clubPswdUpdateInput, clubId), ResponseCode.OK);
     }
 
 //    @PatchMapping(value = "/club/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/example/moim/club/controller/ClubController.java
+++ b/src/main/java/com/example/moim/club/controller/ClubController.java
@@ -28,14 +28,14 @@ public class ClubController implements ClubControllerDocs{
 
     private final UserRepository userRepository;
 
-    @PostMapping(value = "/club", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/clubs", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse<ClubSaveOutput> clubSave(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @ModelAttribute @Valid ClubInput clubInput) throws IOException {
 //    public BaseResponse<ClubSaveOutput> clubSave(@ModelAttribute @Valid ClubInput clubInput) throws IOException {
 //        User user = userRepository.findById(1L).get();
         return BaseResponse.onSuccess(clubCommandService.saveClub(userDetailsImpl.getUser(), clubInput), ResponseCode.OK);
     }
 
-    @PatchMapping(value = "/club/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = "/clubs/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse<ClubUpdateOutput> clubUpdate(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @ModelAttribute ClubUpdateInput clubUpdateInput, @PathVariable("id") Long clubId) throws IOException {
 //    public BaseResponse<ClubUpdateOutput> clubUpdate(@ModelAttribute ClubUpdateInput clubUpdateInput, @PathVariable("id") Long clubId) throws IOException {
 //        User user = userRepository.findById(1L).get();
@@ -48,7 +48,7 @@ public class ClubController implements ClubControllerDocs{
         return BaseResponse.onSuccess(clubQueryService.searchClub(clubSearchCond), ResponseCode.OK);
     }
 
-    @PostMapping("/club/{id}/join")
+    @PostMapping("/clubs/{id}/join")
     public BaseResponse<UserClubOutput> clubUserSave(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody ClubUserSaveInput clubUserSaveInput, @PathVariable("id") Long clubId) {
 //    public BaseResponse<UserClubOutput> clubUserSave(@RequestBody ClubUserSaveInput clubUserSaveInput, @PathVariable("id") Long clubId) {
 //        User user = userRepository.findById(1L).get();
@@ -60,21 +60,26 @@ public class ClubController implements ClubControllerDocs{
 //        return clubService.inviteClubUser(userDetailsImpl.getUser(), clubInviteInput);
 //    }
 
-    @PatchMapping("/club/{id}/role")
+    @DeleteMapping("/clubs/{id}/users")
+    public BaseResponse<String> clubUserDelete(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @PathVariable("id") Long clubId, @RequestBody ClubUserDeleteInput clubUserDeleteInput) {
+        return BaseResponse.onSuccess(clubCommandService.deleteClubUser(userDetailsImpl.getUser(), clubId, clubUserDeleteInput.getUserId()), ResponseCode.OK);
+    }
+
+    @PatchMapping("/clubs/{id}/role")
     public BaseResponse<UserClubOutput> clubUserUpdate(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody ClubUserUpdateInput clubInput, @PathVariable("id") Long clubId) {
 //    public BaseResponse<UserClubOutput> clubUserUpdate(@RequestBody ClubUserUpdateInput clubInput, @PathVariable("id") Long clubId) {
 //        User user = userRepository.findById(1L).get();
         return BaseResponse.onSuccess(clubCommandService.updateClubUser(userDetailsImpl.getUser(), clubInput, clubId), ResponseCode.OK);
     }
 
-    @GetMapping("/club/{id}")
+    @GetMapping("/clubs/{id}")
     public BaseResponse<ClubOutput> clubFind(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @PathVariable("id") Long clubId) {
 //    public BaseResponse<ClubOutput> clubFind(@Parameter(description = "조회할 모임 ID", required = true, example = "1") @PathVariable("id") Long id) {
 //        User user = userRepository.findById(1L).get();
         return BaseResponse.onSuccess(clubQueryService.findClub(clubId, userDetailsImpl.getUser()), ResponseCode.OK);
     }
 
-    @PatchMapping(value = "/club/{id}/password", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = "/clubs/{id}/password", consumes = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse clubPasswordUpdate(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody @Valid ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable("id") Long clubId) {
 //    public BaseResponse clubPasswordUpdate(@RequestBody @Valid ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable("id") Long clubId) {
 //        User user = userRepository.findById(1L).get();

--- a/src/main/java/com/example/moim/club/controller/ClubControllerDocs.java
+++ b/src/main/java/com/example/moim/club/controller/ClubControllerDocs.java
@@ -33,6 +33,9 @@ public interface ClubControllerDocs {
     BaseResponse<UserClubOutput> clubUserSave(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody ClubUserSaveInput clubInput, @PathVariable("id") Long clubId);
 //    BaseResponse<UserClubOutput> clubUserSave(@RequestBody ClubUserSaveInput clubInput, @PathVariable Long clubId);
 
+    @Operation(summary = "모임에서 내보내기")
+    BaseResponse<String> clubUserDelete(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @PathVariable("id") Long clubId, @RequestBody ClubUserDeleteInput clubUserDeleteInput);
+
 //    @Operation(summary = "모임에 초대")
 //    UserClubOutput clubUserInvite(@AuthenticationPrincipal userDetailsImpl userDetailsImpl, @RequestBody ClubUserSaveInput clubInput);
 

--- a/src/main/java/com/example/moim/club/controller/ClubControllerDocs.java
+++ b/src/main/java/com/example/moim/club/controller/ClubControllerDocs.java
@@ -48,7 +48,7 @@ public interface ClubControllerDocs {
 //    BaseResponse<ClubOutput> clubFind(@PathVariable("id") Long clubId);
 
     @Operation(summary = "모임 비밀번호 변경")
-    BaseResponse clubPasswordUpdate(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable("id") Long clubId);
+    BaseResponse<String> clubPasswordUpdate(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl, @RequestBody ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable("id") Long clubId);
 //    BaseResponse clubPasswordUpdate(@RequestBody ClubPswdUpdateInput clubPswdUpdateInput, @PathVariable Long clubId);
 
 //    @Operation(summary = "모임 사진 변경")

--- a/src/main/java/com/example/moim/club/dto/request/ClubInput.java
+++ b/src/main/java/com/example/moim/club/dto/request/ClubInput.java
@@ -1,5 +1,7 @@
 package com.example.moim.club.dto.request;
 
+import com.example.moim.club.exception.advice.ClubControllerAdvice;
+import com.example.moim.global.exception.ResponseCode;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
@@ -14,9 +16,9 @@ public class ClubInput {
     private String title;
     @NotBlank(message = "모임 설명을 적어야합니다!")
     private String explanation;
-    @NotBlank(message = "모임 소개를 적어야합니다!")
+    @NotBlank(message = "모임 한줄 소개를 적어야합니다!")
     private String introduction;
-    @NotBlank(message = "클럽 카테고리를 지정해야합니다!")
+    @NotBlank(message = "모임 종류를 지정해야합니다!")
     private String clubCategory;
     private String university;
     @NotBlank(message = "성별을 지정해야합니다!")
@@ -29,6 +31,8 @@ public class ClubInput {
     private String sportsType;
     @NotBlank(message = "모임 비밀번호를 적어야합니다!")
     private String clubPassword;
+    @NotBlank(message = "모임 확인 비밀번호를 적어야합니다!")
+    private String clubCheckPassword;
     private MultipartFile profileImg;
     @NotBlank(message = "메인 유니폼 색을 지정해야합니다!")
     private String mainUniformColor;
@@ -36,7 +40,7 @@ public class ClubInput {
     private String subUniformColor;
 
     @Builder
-    public ClubInput(String title, String explanation, String introduction, String clubCategory, String university, String gender, String activityArea, String ageRange, String sportsType, String clubPassword, MultipartFile profileImg, String mainUniformColor, String subUniformColor) {
+    public ClubInput(String title, String explanation, String introduction, String clubCategory, String university, String gender, String activityArea, String ageRange, String sportsType, String clubPassword, String clubCheckPassword,MultipartFile profileImg, String mainUniformColor, String subUniformColor) {
         this.title = title;
         this.explanation = explanation;
         this.introduction = introduction;
@@ -46,6 +50,7 @@ public class ClubInput {
         this.activityArea = activityArea;
         this.ageRange = ageRange;
         this.sportsType = sportsType;
+        this.clubCheckPassword = clubCheckPassword;
         this.clubPassword = clubPassword;
         this.profileImg = profileImg;
         this.mainUniformColor = mainUniformColor;

--- a/src/main/java/com/example/moim/club/dto/request/ClubUserDeleteInput.java
+++ b/src/main/java/com/example/moim/club/dto/request/ClubUserDeleteInput.java
@@ -1,0 +1,8 @@
+package com.example.moim.club.dto.request;
+
+import lombok.Data;
+
+@Data
+public class ClubUserDeleteInput {
+    private Long userId;
+}

--- a/src/main/java/com/example/moim/club/entity/Club.java
+++ b/src/main/java/com/example/moim/club/entity/Club.java
@@ -75,6 +75,9 @@ public class Club extends BaseEntity {
         club.activityArea = ActivityArea.fromKoreanName(clubInput.getActivityArea()).get();
         club.sportsType = SportsType.fromKoreanName(clubInput.getSportsType()).get();
         club.ageRange = AgeRange.fromKoreanName(clubInput.getAgeRange()).get();
+        if (!clubInput.getClubPassword().equals(clubInput.getClubCheckPassword())) {
+            throw new ClubControllerAdvice(ResponseCode.CLUB_CHECK_PASSWORD_INCORRECT);
+        }
         club.clubPassword = clubInput.getClubPassword();
         club.profileImgPath = profileImgPath;
         club.mainUniformColor = clubInput.getMainUniformColor();

--- a/src/main/java/com/example/moim/club/repository/UserClubRepository.java
+++ b/src/main/java/com/example/moim/club/repository/UserClubRepository.java
@@ -47,4 +47,6 @@ public interface UserClubRepository extends JpaRepository<UserClub, Long> {
             " where uc.club = :club" +
             " and (uc.clubRole = 'STAFF')")
     List<UserClub> findAdminByClub(@Param("club") Club Club);
+
+    void deleteByClubIdAndUserId(Long clubId, Long userId);
 }

--- a/src/main/java/com/example/moim/club/service/ClubCommandService.java
+++ b/src/main/java/com/example/moim/club/service/ClubCommandService.java
@@ -13,6 +13,6 @@ public interface ClubCommandService {
     UserClubOutput saveClubUser(User user, ClubUserSaveInput clubUserSaveInput, Long clubId);
     String deleteClubUser(User user, Long clubId, Long userId);
     UserClubOutput updateClubUser(User user, ClubUserUpdateInput clubInput, Long clubId);
-    void clubPasswordUpdate(User user, ClubPswdUpdateInput clubPswdUpdateInput, Long clubId);
+    String clubPasswordUpdate(User user, ClubPswdUpdateInput clubPswdUpdateInput, Long clubId);
 
 }

--- a/src/main/java/com/example/moim/club/service/ClubCommandService.java
+++ b/src/main/java/com/example/moim/club/service/ClubCommandService.java
@@ -11,6 +11,7 @@ public interface ClubCommandService {
     ClubSaveOutput saveClub(User user, ClubInput clubInput) throws IOException;
     ClubUpdateOutput updateClub(User user, ClubUpdateInput clubUpdateInput, Long clubId) throws IOException;
     UserClubOutput saveClubUser(User user, ClubUserSaveInput clubUserSaveInput, Long clubId);
+    String deleteClubUser(User user, Long clubId, Long userId);
     UserClubOutput updateClubUser(User user, ClubUserUpdateInput clubInput, Long clubId);
     void clubPasswordUpdate(User user, ClubPswdUpdateInput clubPswdUpdateInput, Long clubId);
 

--- a/src/main/java/com/example/moim/club/service/ClubCommandServiceImpl.java
+++ b/src/main/java/com/example/moim/club/service/ClubCommandServiceImpl.java
@@ -92,6 +92,20 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         throw new ClubControllerAdvice(ResponseCode.CLUB_PASSWORD_INCORRECT);
     }
 
+    @Transactional
+    public String deleteClubUser(User user, Long clubId, Long userId) {
+
+        User targetUser = getUser(userId);
+
+        // 관리자 권한 확인
+        validateIsStaff(getUserClub(getClub(clubId), user));
+
+        userClubRepository.deleteByClubIdAndUserId(clubId, userId);
+
+        return targetUser.getName() + "님이 가입에서 내보내졌습니다.";
+
+    }
+
 //    public UserClubOutput inviteClubUser(User user, ClubInviteInput clubInviteInput) {
 //        userRepository.findById(clubInviteInput.getUser().)
 //    }
@@ -130,8 +144,22 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         club.updateClubPassword(clubPswdUpdateInput.getNewPassword());
     }
 
+    private UserClub getUserClub(Club club, User user) {
+        return userClubRepository.findByClubAndUser(club, user).orElseThrow(() -> new ClubControllerAdvice(ResponseCode.CLUB_USER_NOT_FOUND));
+    }
+
     private Club getClub(Long clubId) {
         return clubRepository.findById(clubId).orElseThrow(() -> new ClubControllerAdvice(ResponseCode.CLUB_NOT_FOUND));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new ClubControllerAdvice(ResponseCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateIsStaff(UserClub userClub) {
+        if (!userClub.getClubRole().equals(ClubRole.STAFF)) {
+            throw new ClubControllerAdvice(ResponseCode.CLUB_PERMISSION_DENIED);
+        }
     }
 
     private void saveClubSearch(Club club) {

--- a/src/main/java/com/example/moim/club/service/ClubCommandServiceImpl.java
+++ b/src/main/java/com/example/moim/club/service/ClubCommandServiceImpl.java
@@ -126,7 +126,7 @@ public class ClubCommandServiceImpl implements ClubCommandService {
     }
 
     @Transactional
-    public void clubPasswordUpdate(User user, ClubPswdUpdateInput clubPswdUpdateInput, Long clubId) {
+    public String clubPasswordUpdate(User user, ClubPswdUpdateInput clubPswdUpdateInput, Long clubId) {
         Club club = getClub(clubId);
 //        Club club = clubRepository.findById(clubPswdUpdateInput.getId()).orElseThrow(() -> new ClubControllerAdvice(ResponseCode.CLUB_NOT_FOUND));
         UserClub userClub = userClubRepository.findByClubAndUser(club, user).orElseThrow(() -> new ClubControllerAdvice(ResponseCode.CLUB_USER_NOT_FOUND));
@@ -141,7 +141,10 @@ public class ClubCommandServiceImpl implements ClubCommandService {
         if (!clubPswdUpdateInput.getNewPassword().equals(clubPswdUpdateInput.getRePassword())) {
             throw new ClubControllerAdvice(ResponseCode.CLUB_CHECK_PASSWORD_INCORRECT);
         }
+
         club.updateClubPassword(clubPswdUpdateInput.getNewPassword());
+
+        return club.getTitle() + "의 비밀번호를 변경하였습니다.";
     }
 
     private UserClub getUserClub(Club club, User user) {

--- a/src/test/java/com/example/moim/club/repository/ClubRepositoryImplTest.java
+++ b/src/test/java/com/example/moim/club/repository/ClubRepositoryImplTest.java
@@ -50,10 +50,10 @@ class ClubRepositoryImplTest {
 
         ClubInput clubInput = ClubInput.builder().title(title).explanation(explanation).introduction(introduction).clubCategory(clubCategory.getKoreanName())
                 .university(university).gender(gender.getKoreanName()).activityArea(activityArea.getKoreanName()).ageRange(ageRange.getKoreanName()).sportsType(sportsType.getKoreanName())
-                .clubPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
+                .clubPassword(clubPassword).clubCheckPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
         ClubInput clubInput2 = ClubInput.builder().title(title2).explanation(explanation).introduction(introduction).clubCategory(clubCategory2.getKoreanName())
                 .university(university).gender(gender.getKoreanName()).activityArea(activityArea.getKoreanName()).ageRange(ageRange.getKoreanName()).sportsType(sportsType.getKoreanName())
-                .clubPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
+                .clubPassword(clubPassword).clubCheckPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
 
         Club savedClub = clubRepository.save(Club.createClub(clubInput, "/club"));
         Club savedClub2 = clubRepository.save(Club.createClub(clubInput2, "/club"));

--- a/src/test/java/com/example/moim/club/service/ClubCommandServiceImplTest.java
+++ b/src/test/java/com/example/moim/club/service/ClubCommandServiceImplTest.java
@@ -75,7 +75,7 @@ class ClubCommandServiceImplTest {
 
         this.clubInput = ClubInput.builder().title(title).explanation(explanation).introduction(introduction).clubCategory(clubCategory.getKoreanName())
                 .university(organization).gender(gender.getKoreanName()).activityArea(activityArea.getKoreanName()).ageRange(ageRange.getKoreanName()).sportsType(sportsType.getKoreanName())
-                .clubPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
+                .clubPassword(clubPassword).clubCheckPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
 
         String updateTitle = "update title";
         String updateExplanation = "update explanation";
@@ -244,6 +244,49 @@ class ClubCommandServiceImplTest {
             clubCommandService.updateClubUser(new User(), clubUserUpdateInput, 1L);
         });
         assertThat(exception.getMessage()).isEqualTo(ResponseCode.CLUB_PERMISSION_DENIED.getMessage());
+        verify(clubRepository, times(1)).findById(any(Long.class));
+        verify(userClubRepository, times(1)).findByClubAndUser(any(Club.class), any(User.class));
+    }
+
+    @Test
+    @DisplayName("운영진은 사용자를 모임에서 내보낼 수 있다")
+    void deleteClubUser() {
+        //given
+        Club club = Club.createClub(clubInput, null);
+
+        //when
+        when(clubRepository.findById(any(Long.class))).thenReturn(Optional.of(club));
+        when(userClubRepository.findByClubAndUser(any(Club.class), any(User.class)))
+                .thenReturn(Optional.of(UserClub.createLeaderUserClub(new User(), club)))
+                .thenReturn(Optional.of(UserClub.createUserClub(new User(), club)));
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(new User()));
+        String result = clubCommandService.deleteClubUser(new User(), 1L, 1L);
+
+        //then
+        assertThat(result).contains("님이 가입에서 내보내졌습니다.");
+        verify(clubRepository, times(1)).findById(any(Long.class));
+        verify(userClubRepository, times(1)).findByClubAndUser(any(Club.class), any(User.class));
+        verify(userClubRepository, times(1)).deleteByClubIdAndUserId(any(Long.class), any(Long.class));
+    }
+
+    @Test
+    @DisplayName("운영진이 아니면 모임에 속한 사용자를 내보내려 할 때 예외가 발생한다")
+    void delete_ClubUser_exception_wrong_permission() {
+        //given
+        Club club = Club.createClub(clubInput, null);
+
+        //when
+        //then
+        when(clubRepository.findById(any(Long.class))).thenReturn(Optional.of(club));
+        when(userClubRepository.findByClubAndUser(any(Club.class), any(User.class)))
+                .thenReturn(Optional.of(UserClub.createUserClub(new User(), club)));
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(new User()));
+
+        Exception exception = assertThrows(ClubControllerAdvice.class, () -> {
+            clubCommandService.deleteClubUser(new User(), 1L, 1L);
+        });
+        assertThat(exception.getMessage()).isEqualTo(ResponseCode.CLUB_PERMISSION_DENIED.getMessage());
+        verify(userRepository, times(1)).findById(any(Long.class));
         verify(clubRepository, times(1)).findById(any(Long.class));
         verify(userClubRepository, times(1)).findByClubAndUser(any(Club.class), any(User.class));
     }

--- a/src/test/java/com/example/moim/club/service/ClubQueryServiceImplTest.java
+++ b/src/test/java/com/example/moim/club/service/ClubQueryServiceImplTest.java
@@ -57,7 +57,7 @@ public class ClubQueryServiceImplTest {
 
         this.clubInput = ClubInput.builder().title(title).explanation(explanation).introduction(introduction).clubCategory(clubCategory.getKoreanName())
                 .university(university).gender(gender.getKoreanName()).activityArea(activityArea.getKoreanName()).ageRange(ageRange.getKoreanName()).sportsType(sportsType.getKoreanName())
-                .clubPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
+                .clubPassword(clubPassword).clubCheckPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
     }
 
     @Test

--- a/src/test/java/com/example/moim/club/service/NoticeCommandServiceImplTest.java
+++ b/src/test/java/com/example/moim/club/service/NoticeCommandServiceImplTest.java
@@ -62,7 +62,7 @@ class NoticeCommandServiceImplTest {
 
         this.clubInput = ClubInput.builder().title(title).explanation(explanation).introduction(introduction).clubCategory(clubCategory.getKoreanName())
                 .university(university).gender(gender.getKoreanName()).activityArea(activityArea.getKoreanName()).ageRange(ageRange.getKoreanName()).sportsType(sportsType.getKoreanName())
-                .clubPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
+                .clubPassword(clubPassword).clubCheckPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
 
         // Notice
         this.noticeInput = NoticeInput.builder().title("notice title").content("notice content").build();

--- a/src/test/java/com/example/moim/club/service/NoticeQueryServiceImplTest.java
+++ b/src/test/java/com/example/moim/club/service/NoticeQueryServiceImplTest.java
@@ -68,7 +68,7 @@ public class NoticeQueryServiceImplTest {
 
         this.clubInput = ClubInput.builder().title(title).explanation(explanation).introduction(introduction).clubCategory(clubCategory.getKoreanName())
                 .university(university).gender(gender.getKoreanName()).activityArea(activityArea.getKoreanName()).ageRange(ageRange.getKoreanName()).sportsType(sportsType.getKoreanName())
-                .clubPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
+                .clubPassword(clubPassword).clubCheckPassword(clubPassword).profileImg(profileImg).mainUniformColor(mainUniformColor).subUniformColor(subUniformColor).build();
 
         // Notice
         this.noticeInput = NoticeInput.builder().title("notice title").content("notice content").build();

--- a/src/test/java/com/example/moim/match/MatchServiceTest.java
+++ b/src/test/java/com/example/moim/match/MatchServiceTest.java
@@ -82,6 +82,7 @@ class MatchServiceTest {
         clubInput.setAgeRange(AgeRange.TWENTIES.getKoreanName());
         clubInput.setSportsType(SportsType.SOCCER.getKoreanName());
         clubInput.setClubPassword("password");
+        clubInput.setClubCheckPassword("password");
         clubInput.setMainUniformColor("흰색");
         clubInput.setSubUniformColor("검은색");
 

--- a/src/test/java/com/example/moim/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/moim/notification/service/NotificationServiceTest.java
@@ -160,6 +160,8 @@ class NotificationServiceTest {
                         .activityArea("서울")
                         .sportsType("축구")
                         .ageRange("20대")
+                        .clubPassword("password")
+                        .clubCheckPassword("password")
                         .build()
                 , "path/to/image"
         );

--- a/src/test/java/com/example/moim/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/example/moim/schedule/service/ScheduleServiceTest.java
@@ -76,7 +76,7 @@ class ScheduleServiceTest {
         this.clubInput = ClubInput.builder().title("title").explanation("explanation").introduction("introduction")
                 .clubCategory(ClubCategory.SMALL_GROUP.getKoreanName()).university("university").gender(Gender.UNISEX.getKoreanName())
                 .activityArea(ActivityArea.SEOUL.getKoreanName()).ageRange(AgeRange.TWENTIES.getKoreanName()).sportsType(SportsType.SOCCER.getKoreanName())
-                .clubPassword("clubPassword").profileImg(new MockMultipartFile("file", "file".getBytes()))
+                .clubPassword("clubPassword").clubCheckPassword("clubPassword").profileImg(new MockMultipartFile("file", "file".getBytes()))
                 .mainUniformColor("mainUniformColor").subUniformColor("subUniformColor").build();
         this.scheduleUpdateInput = ScheduleUpdateInput.builder().clubId(1L).id(1L).title("update title").location("update location")
                 .startTime(LocalDateTime.of(2024, 12, 13, 12, 30, 0))


### PR DESCRIPTION
## ✨ feat: 유저 내보내기 기능 구현
- feat: 유저 내보내기 기능 구현
- refactor: 모임 비밀번호 변경 응답 값 변경
- refactor: 모임 생성할 때, 비밀번호와 비밀번호 확인 유효성 검사 추가

## 📌 변경 사항 (What’s changed?)
- 유저 내보내기 기능 구현(UserClub 에서 삭제)
- 모임 비밀번호 변경 후 변경 완료했다는 응답 값 반환하도록 변경
- 모임 생성할 때, 변경하는 비밀번호 입력 후 비밀번호 확인 값 체크하는 로직 추가

## ⚙️ 변경 이유 (Why?)
- 유저 내보내기 기능 구현
- 모임 비밀번호 변경 후 응답 값 없는 것에서 변경 완료되었다는 반환 값 추가하는 것이 더 명확
- 비밀번호 입력과 비밀번호 확인 체크하는게 잘못된 비밀번호 DB에 들어가지 않도록 하는 안정성 높음

## ✅ 테스트 방법 (How to test?)
- ClubCommandServiceTest 에 추가

## 💬리뷰 요구사항

> 편하게 코드 리뷰해주세요~!
